### PR TITLE
ACM-42618: Close placeholder in oc apply command

### DIFF
--- a/release_notes/known_issues_install.adoc
+++ b/release_notes/known_issues_install.adoc
@@ -89,7 +89,7 @@ spec:
 +
 [source,bash]
 ----
-oc apply -f <filename.yaml
+oc apply -f <filename.yaml>
 ----
 
 link:https://issues.redhat.com/browse/ACM-31036[ACM-31036]


### PR DESCRIPTION
## Summary

The workaround command in the kubevirt-hyperconverged add-on upgrade known issue was missing the closing `>` on the file placeholder.

**Before:**
```
oc apply -f <filename.yaml
```

**After:**
```
oc apply -f <filename.yaml>
```

## Affected page

- https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.17/html-single/release_notes/index#add-on-stuck-upgrade

## Files changed

- `release_notes/known_issues_install.adoc`

## Issue

- https://redhat.atlassian.net/browse/ACM-42618

## Test plan

- [ ] Confirm the bash example in *The kubevirt-hyperconverged add-on is stuck in `in progress` status during upgrade* ends with `<filename.yaml>`
- [ ] Confirm no other changes in the file


Made with [Cursor](https://cursor.com)