### PR TITLE
ACM-42619: Use straight quotes in rosa grep command

### DIFF
--- a/release_notes/known_issues_console.adoc
+++ b/release_notes/known_issues_console.adoc
@@ -105,7 +105,7 @@ To get the `cluster-ID`, run the following command from the {rosa} command line 
 
 [source,bash]
 ----
-rosa describe cluster --cluster=<cluster-name> | grep -o ’^ID:.*
+rosa describe cluster --cluster=<cluster-name> | grep -o '^ID:.*'
 ----
 
 link:https://issues.redhat.com/browse/ACM-10651[ACM-10651]


### PR DESCRIPTION
## Summary

The workaround command in the cluster-ID known issue used a curly closing quote (`’`) instead of a straight apostrophe (`'`), and the grep string was never closed. Users cannot copy-paste the command.

`--cluster=<cluster-name>` is already correct. This change is the quoting only.

**Before:**
```
rosa describe cluster --cluster=<cluster-name> | grep -o ’^ID:.*
```

**After:**
```
rosa describe cluster --cluster=<cluster-name> | grep -o '^ID:.*'
```

## Affected page

- https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.17/html-single/release_notes/index#cluster-id-ocm-console

The same broken quoting is also in 2.16 and 2.15 published docs.

## Files changed

- `release_notes/known_issues_console.adoc`

## Issue

- https://redhat.atlassian.net/browse/ACM-42619

## Test plan

- [ ] Confirm the bash example in *Issues with entering the cluster-ID in the OpenShift Cloud Manager console* uses straight quotes and a closed grep string: `grep -o '^ID:.*'`
- [ ] Confirm `--cluster=<cluster-name>` is unchanged
- [ ] Confirm the example still renders as a bash code block
