### PR TITLE
ACM-42620: Nest annotations under metadata in Ansible YAML

### DIFF
--- a/release_notes/known_issues_application.adoc
+++ b/release_notes/known_issues_application.adoc
@@ -179,9 +179,9 @@ kind: Subscription
 metadata:
   name: sub-rhacm-gitops-demo
   namespace: hello-openshift
-annotations:
-  apps.open-cluster-management.io/github-path: myapp
-  apps.open-cluster-management.io/github-branch: master
+  annotations:
+    apps.open-cluster-management.io/github-path: myapp
+    apps.open-cluster-management.io/github-branch: master
 spec:
   hooksecretref:
       name: toweraccess
@@ -216,9 +216,9 @@ kind: Subscription
 metadata:
   name: sub-rhacm-gitops-demo
   namespace: hello-openshift
-annotations:
-  apps.open-cluster-management.io/github-path: myapp
-  apps.open-cluster-management.io/github-branch: master
+  annotations:
+    apps.open-cluster-management.io/github-path: myapp
+    apps.open-cluster-management.io/github-branch: master
 spec:
   hooksecretref:
       name: toweraccess


### PR DESCRIPTION
## Summary

Both Subscription samples in the Ansible hook stand-alone known issue had `annotations:` at the same indent as `metadata:`. Kubernetes treats that as a root-level field and rejects the YAML.

This change only nests `annotations` under `metadata` in both samples. Other YAML fields are unchanged.

**Before:**
```yaml
metadata:
  name: sub-rhacm-gitops-demo
  namespace: hello-openshift
annotations:
  apps.open-cluster-management.io/github-path: myapp
```

**After:**
```yaml
metadata:
  name: sub-rhacm-gitops-demo
  namespace: hello-openshift
  annotations:
    apps.open-cluster-management.io/github-path: myapp
```

## Affected page

- https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.17/html-single/release_notes/index#application-ansible-standalone

The same invalid indent is also in 2.16, 2.15, 2.14, and 2.13 docs.

## Files changed

- `release_notes/known_issues_application.adoc`

## Issue

- https://redhat.atlassian.net/browse/ACM-42620

## Test plan

- [ ] Confirm both Subscription examples nest `annotations` under `metadata`
- [ ] Confirm the PlacementRule sample is unchanged
- [ ] Confirm `spec` fields (`hooksecretref`, `placement`) are unchanged
- [ ] Confirm the samples still render as YAML blocks


Made with [Cursor](https://cursor.com)