### PR TITLE
https://redhat.atlassian.net/browse/ACM-42619: Use straight quotes in…

### DIFF
--- a/release_notes/known_issues_console.adoc
+++ b/release_notes/known_issues_console.adoc
@@ -105,7 +105,7 @@ To get the `cluster-ID`, run the following command from the {rosa} command line 
 
 [source,bash]
 ----
-rosa describe cluster --cluster=<cluster-name> | grep -o ’^ID:.*
+rosa describe cluster --cluster=<cluster-name> | grep -o '^ID:.*'
 ----
 
 link:https://issues.redhat.com/browse/ACM-10651[ACM-10651]


### PR DESCRIPTION
… rosa grep command

The cluster-ID known issue used a curly quote and left the grep string unclosed, so the command cannot be copy-pasted.